### PR TITLE
Fix three bugs in the codebase

### DIFF
--- a/apps/fcm-api/src/auth/guards/jwt.guard.ts
+++ b/apps/fcm-api/src/auth/guards/jwt.guard.ts
@@ -19,9 +19,6 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
       context.getClass(),
     ])
 
-    const request = context.switchToHttp().getRequest()
-    console.log('JWT Debug:', request.headers.authorization)
-
     if (isPublic) {
       return true
     }

--- a/apps/fcm-api/src/auth/guards/jwt.guard.ts
+++ b/apps/fcm-api/src/auth/guards/jwt.guard.ts
@@ -26,7 +26,9 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     return super.canActivate(context)
   }
 
-  handleRequest(err: any, user: any, info: any) {
+  // 'info' is part of AuthGuard signature but unused here
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  handleRequest(err: any, user: any, _info: any) {
     if (err || !user) {
       throw err || new UnauthorizedException('Invalid token')
     }

--- a/apps/fcm-api/src/scheduler/scheduler.service.ts
+++ b/apps/fcm-api/src/scheduler/scheduler.service.ts
@@ -348,27 +348,29 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     return task
   }
 
-  async pauseTask(taskId: string): Promise<TaskScheduleDto> {
+  async pauseTask(taskId: string): Promise<TaskScheduleDto | null> {
     const job = this.activeJobs.get(taskId)
     if (job) {
       job.stop()
       this.activeJobs.delete(taskId)
-      await taskScheduleRepository.update({
+      return await taskScheduleRepository.update({
         id: taskId,
         state: TaskState.DISABLED,
       })
-    } else return null
+    }
+    return null
   }
 
-  async resumeTask(taskId: string): Promise<TaskScheduleDto> {
+  async resumeTask(taskId: string): Promise<TaskScheduleDto | null> {
     const config = await taskScheduleRepository.findById(taskId)
     if (config && !this.activeJobs.has(taskId)) {
       await this.scheduleTask(config)
-      await taskScheduleRepository.update({
+      return await taskScheduleRepository.update({
         id: taskId,
         state: TaskState.ENABLED,
       })
-    } else return null
+    }
+    return null
   }
 
   async updateTask(

--- a/apps/fcm-api/tsconfig.json
+++ b/apps/fcm-api/tsconfig.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"],
-      "@fcm/shared": ["../../packages/fcm-shared/src/index.ts"],
+      "@fcm/shared": ["../../packages/fcm-shared/src/index"],
       "@fcm/shared/*": ["../../packages/fcm-shared/src/*"],
-      "@fcm/storage": ["../../packages/fcm-storage/src/index.ts"],
+      "@fcm/storage": ["../../packages/fcm-storage/src/index"],
       "@fcm/storage/*": ["../../packages/fcm-storage/src/*"]
     }
   },

--- a/apps/fcm-api/tsconfig.json
+++ b/apps/fcm-api/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../packages/typescript-config/nestjs.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@fcm/shared": ["../../packages/fcm-shared/src/index"],

--- a/apps/fcm-api/tsconfig.json
+++ b/apps/fcm-api/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@fcm/typescript-config/nestjs.json",
   "compilerOptions": {
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@fcm/shared": ["../../packages/fcm-shared/src/index.ts"],
+      "@fcm/shared/*": ["../../packages/fcm-shared/src/*"],
+      "@fcm/storage": ["../../packages/fcm-storage/src/index.ts"],
+      "@fcm/storage/*": ["../../packages/fcm-storage/src/*"]
     }
   },
   "include": ["src/**/*.ts", "src/examples.ts", "../../packages/fcm-shared/src/logging/logging.config.ts"],

--- a/apps/fcm-api/tsconfig.json
+++ b/apps/fcm-api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@fcm/typescript-config/nestjs.json",
+  "extends": "../../packages/typescript-config/nestjs.json",
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"],

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "npm-check-updates": "^17.1.0",
     "prettier": "^3.4.2",
     "rimraf": "^6.0.1",
-    "turbo": "^2.3.3"
+    "turbo": "^2.3.3",
+    "typescript": "^5.7.2",
+    "@types/node": "^20.17.10"
   },
   "packageManager": "pnpm@9.15.3",
   "engines": {

--- a/packages/fcm-shared/package.json
+++ b/packages/fcm-shared/package.json
@@ -115,6 +115,7 @@
     "@fcm/eslint-config": "workspace:*",
     "@fcm/typescript-config": "workspace:*",
     "@types/node": "^20.17.10",
+    "@types/axios": "^0.14.0",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
     "typescript": "5.7.2"

--- a/packages/fcm-shared/src/amadeus/clients/base.ts
+++ b/packages/fcm-shared/src/amadeus/clients/base.ts
@@ -121,8 +121,10 @@ export abstract class BaseClient {
   protected async request<T>(path: string, options: any = {}): Promise<T> {
     try {
       const accessToken = await this.ensureValidToken()
-      // Use baseUrl for API requests, not authentication
-      const url = `${path}`
+      // Ensure we construct the full request URL.
+      // If the provided path is already an absolute URL (starts with http/https),
+      // we use it as-is. Otherwise we prefix it with the configured baseUrl.
+      const url = /^https?:\/\//.test(path) ? path : `${this.baseUrl}${path}`
 
       const axiosConfig = {
         ...options,

--- a/packages/fcm-shared/tsconfig.json
+++ b/packages/fcm-shared/tsconfig.json
@@ -8,7 +8,8 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "noEmit": false,
-    "emitDeclarationOnly": false
+    "emitDeclarationOnly": false,
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/fcm-storage/package.json
+++ b/packages/fcm-storage/package.json
@@ -54,6 +54,7 @@
     "@fcm/typescript-config": "workspace:*",
     "@types/bcrypt": "^5.0.2",
     "@types/node": "^20.17.10",
+    "@types/axios": "^0.14.0",
     "prisma": "^6.1.0",
     "rimraf": "^5.0.5",
     "ts-loader": "^9.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@fcm/typescript-config':
         specifier: workspace:*
         version: link:packages/typescript-config
+      '@types/node':
+        specifier: ^20.17.10
+        version: 20.17.10
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.18.0
         version: 8.18.2(@typescript-eslint/parser@8.18.2(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0)(typescript@5.7.2)
@@ -41,6 +44,9 @@ importers:
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
+      typescript:
+        specifier: ^5.7.2
+        version: 5.7.2
 
   apps/fcm-api:
     dependencies:
@@ -389,6 +395,9 @@ importers:
       '@fcm/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@types/axios':
+        specifier: ^0.14.0
+        version: 0.14.4
       '@types/node':
         specifier: ^20.17.10
         version: 20.17.10
@@ -453,6 +462,9 @@ importers:
       '@fcm/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@types/axios':
+        specifier: ^0.14.0
+        version: 0.14.4
       '@types/bcrypt':
         specifier: ^5.0.2
         version: 5.0.2
@@ -1987,6 +1999,10 @@ packages:
   '@turbo/workspaces@1.13.4':
     resolution: {integrity: sha512-3uYg2b5TWCiupetbDFMbBFMHl33xQTvp5DNg0fZSYal73Z9AlFH9yWabHWMYw6ywmwM1evkYRpTVA2n7GgqT5A==}
     hasBin: true
+
+  '@types/axios@0.14.4':
+    resolution: {integrity: sha512-9JgOaunvQdsQ/qW2OPmE5+hCeUB52lQSolecrFrthct55QekhmXEwT203s20RL+UHtCQc15y3VXpby9E7Kkh/g==}
+    deprecated: This is a stub types definition. axios provides its own type definitions, so you do not need this installed.
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -7365,6 +7381,12 @@ snapshots:
       rimraf: 3.0.2
       semver: 7.6.3
       update-check: 1.5.4
+
+  '@types/axios@0.14.4':
+    dependencies:
+      axios: 1.7.9
+    transitivePeerDependencies:
+      - debug
 
   '@types/babel__core@7.20.5':
     dependencies:


### PR DESCRIPTION
<!-- Implement initial bug fixes and resolve subsequent module resolution and type declaration errors. -->

The initial bug fixes introduced several TypeScript and module resolution issues, particularly concerning workspace package imports, `tsconfig.json` inheritance, and missing type declarations for external libraries. This PR addresses these by correcting `tsconfig` paths, adding explicit path aliases for monorepo packages, and ensuring all necessary `@types` packages are installed, making the entire workspace fully compilable.